### PR TITLE
Remove stats (FPS), info (#tris) and short-cut save/restore

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -147,8 +147,8 @@
 				return this.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,");
 			};
 			//
-			stats = new Stats();
-			document.body.appendChild( stats.domElement );
+			//stats = new Stats();
+			//document.body.appendChild( stats.domElement );
 
 			var editor = new OpenSimEditor();
 			
@@ -212,7 +212,8 @@
 				sceneLightColor.onChange(function (value) {
 				editor.updateSceneLight('color', value);
 				});*/
-				gui.remember(knobs);
+			    // No save/retrieve settings will go thru File menu or popup
+				// gui.remember(knobs);
 			}
 
 			var viewport = new OpenSimViewport( editor );

--- a/editor/js/OpenSimViewport.js
+++ b/editor/js/OpenSimViewport.js
@@ -10,7 +10,7 @@ var OpenSimViewport = function ( editor ) {
 	container.setId( 'viewport' );
 	container.setPosition( 'absolute' );
 
-	container.add( new Viewport.Info( editor ) );
+	//container.add( new Viewport.Info( editor ) );
 
 	var scene = editor.scene;
 	var sceneHelpers = editor.sceneHelpers;
@@ -702,7 +702,7 @@ var OpenSimViewport = function ( editor ) {
 
 		sceneHelpers.updateMatrixWorld();
 		scene.updateMatrixWorld();
-		stats.update();
+		//stats.update();
 		if (renderer != null) {
 		    renderer.clear();
 


### PR DESCRIPTION
reduce clutter on visualiser window