### PR TITLE
Light follow camera

### DIFF
--- a/editor/js/OpenSimViewport.js
+++ b/editor/js/OpenSimViewport.js
@@ -73,7 +73,7 @@ var OpenSimViewport = function ( editor ) {
 
 		}
 
-		render();
+ 		render();
 
 	} );
 	transformControls.addEventListener( 'mouseDown', function () {
@@ -382,7 +382,7 @@ var OpenSimViewport = function ( editor ) {
 	var saveTimeout;
 
 	signals.cameraChanged.add( function () {
-
+                editor.sceneLight.position.copy(editor.camera.position);
 		render();
 
 	} );


### PR DESCRIPTION
Make default directional light follow camera similar to earlier versions of OpenSim, my need to remove short cut that controls position or add a separate light if makes sense