### PR TITLE
Disable frustum culling for muscles

### DIFF
--- a/editor/js/SkinnedMuscle.js
+++ b/editor/js/SkinnedMuscle.js
@@ -23,6 +23,7 @@ THREE.SkinnedMuscle = function(geom, points, material) {
     THREE.SkinnedMesh.call( this, geom );
     this.material = material;
     this.material.skinning = true;
+    this.frustumCulled = false;
 };
 THREE.SkinnedMuscle.prototype = Object.create( THREE.SkinnedMesh.prototype );
 THREE.SkinnedMuscle.prototype.constructor = THREE.SkinnedMuscle;


### PR DESCRIPTION
Fix muscle disappearance on zoom due to Frustum Culling (done on CPU) while vertices live on GPU.