### PR TITLE
Fix flattened muscles

### DIFF
--- a/editor/js/OpenSimLoader.js
+++ b/editor/js/OpenSimLoader.js
@@ -253,7 +253,7 @@ Object.assign( THREE.OpenSimLoader.prototype, {
 
 				    case 'PathGeometry':
                 //CylinderGeometry(radiusTop, radiusBottom, height, radiusSegments, heightSegments, openEnded, thetaStart, thetaLength)
-				        geometry = new THREE.CylinderGeometry(8, 8, 2*data.segments, 8, 2*data.segments, true);
+				        geometry = new THREE.CylinderGeometry(8, 8, data.segments, 8, 2*data.segments-2, true);
 
 				        break;
 

--- a/editor/js/OpenSimLoader.js
+++ b/editor/js/OpenSimLoader.js
@@ -252,8 +252,8 @@ Object.assign( THREE.OpenSimLoader.prototype, {
 						break;
 
 				    case 'PathGeometry':
-
-				        geometry = new THREE.CylinderGeometry(5, 5, data.segments, 8, data.segments, true);
+                //CylinderGeometry(radiusTop, radiusBottom, height, radiusSegments, heightSegments, openEnded, thetaStart, thetaLength)
+				        geometry = new THREE.CylinderGeometry(8, 8, 2*data.segments, 8, 2*data.segments, true);
 
 				        break;
 
@@ -558,19 +558,19 @@ Object.assign( THREE.OpenSimLoader.prototype, {
 			    case 'Frame':
 
                                         object = new THREE.AxisHelper(data.size);
-                                        
+
                                         break;
 
 			    case 'GeometryPath':
                                         object = new THREE.SkinnedMuscle(getGeometry(data.geometry), data.points,  getMaterial( data.material ));
-                                        
+
                                         break;
-                                
+
                             case 'Arrow':
                                         object = new THREE.ArrowHelper(data.dir, data.origin, 1000, data.color);
-                                        
+
                                         break;
-                                        
+
                             default:
 					object = new THREE.Object3D();
 

--- a/editor/js/SkinnedMuscle.js
+++ b/editor/js/SkinnedMuscle.js
@@ -6,7 +6,7 @@ THREE.SkinnedMuscle = function(geom, points, material) {
     this.pathpoints = points;
     this.pathpointObjects = [];
     geom.bones = [];
-    this.DEBUG = true;
+
     for (var i=0; i< 2*points.length-2; i++) {
         var bone = new THREE.Bone();
         bone.pos = [0, 0, 0];
@@ -99,15 +99,6 @@ THREE.SkinnedMuscle.prototype.updateMatrixWorld = function( force ) {
             // back along the vector from pt1 to pt2
             bones[b].position.add(vec);
             bones[b].quaternion.setFromUnitVectors(vFrom, vTo);
-
-            if (this.DEBUG) {
-                console.warn("Path point name: " + thisPathpointObject.name);
-                console.warn("Num pathpoints = " + this.pathpoints.length);
-                console.warn("Num bones = " + this.children.length);
-                console.warn("This is vec:" + vec.toArray());
-                //console.dir(this.children[2*p+1]);
-                this.DEBUG = false;
-            }
 
             bones[b-1].updateMatrixWorld();
             bones[b++].updateMatrixWorld();

--- a/editor/js/SkinnedMuscle.js
+++ b/editor/js/SkinnedMuscle.js
@@ -53,8 +53,8 @@ THREE.SkinnedMuscle.prototype.updateMatrixWorld = function( force ) {
 
                 if (pptObject2 !== undefined) {
                 // define the two bones of a segement of the path together
-                    bones[b].geometry = new THREE.SphereGeometry(8, 64, 64); //pptObject1.geometry;
-                    bones[++b].geometry = new THREE.SphereGeometry(8, 64, 64); //pptObject2.geometry;
+                    bones[b].geometry = pptObject1.geometry;
+                    bones[++b].geometry = pptObject2.geometry;
                 }
                 b++;
             }

--- a/editor/js/SkinnedMuscle.js
+++ b/editor/js/SkinnedMuscle.js
@@ -1,18 +1,23 @@
 /**
- * @author Ayman Habib 
+ * @author Ayman Habib
  */
 THREE.SkinnedMuscle = function(geom, points, material) {
     // Create bones for uuids in geometryPath
     this.pathpoints = points;
     this.pathpointObjects = [];
     geom.bones = [];
-    for (var i=0; i<points.length; i++) {
+    this.DEBUG = true;
+    for (var i=0; i< 2*points.length; i++) {
         var bone = new THREE.Bone();
         bone.pos = [0, 0, 0];
         bone.rotq = [0, 0, 0, 1];
-        bone.ppt = this.pathpoints[i];
+        //bone.rotq = [0.70711, 0, 0, 0.70711]; //[0, 0, 0, 1];
+        bone.ppt = this.pathpoints[Math.floor(i/2)];
         geom.bones.push(bone);
     }
+
+    console.warn("Num bones:" + geom.bones.length);
+
     var numVerticesPerLevel = geom.vertices.length / points.length;
     for ( var i = 0; i < geom.vertices.length; i ++ ) {
         var skinIndex = Math.floor(i / numVerticesPerLevel);
@@ -24,8 +29,10 @@ THREE.SkinnedMuscle = function(geom, points, material) {
     this.material = material;
     this.material.skinning = true;
 };
+
 THREE.SkinnedMuscle.prototype = Object.create( THREE.SkinnedMesh.prototype );
 THREE.SkinnedMuscle.prototype.constructor = THREE.SkinnedMuscle;
+
 THREE.SkinnedMuscle.prototype.updateMatrixWorld = function( force ) {
 // if has pathpoints attribute then it's a muscle
 // Cycle through pathpoints, update their matrixworld
@@ -46,16 +53,42 @@ THREE.SkinnedMuscle.prototype.updateMatrixWorld = function( force ) {
     // Compute reverse transform from Ground to Scene (usually this's inverse translation)
     // This is necessary since the blending to compute vertices adds offset twice
     var mat = new THREE.Matrix4().getInverse(this.parent.matrixWorld);
-    var vec = new THREE.Vector3().setFromMatrixPosition(mat);
+    var vec = new THREE.Vector3(0, 0.02, 0.05); //.setFromMatrixPosition(mat);
 
-    for (var b = 0; b < this.pathpoints.length; b++) {
-        var nextPathpointObject = this.pathpointObjects[b];
-        if (nextPathpointObject !== undefined) {
-            this.children[b].position.setFromMatrixPosition(nextPathpointObject.matrixWorld);
-            this.children[b].position.add(vec);
+    // clycle through each PathPoint and add two "bones" for each point
+    // one aligned with the currect parent and the second to the next
+    for (var p = 0; p < this.pathpoints.length; p++) {
+        var thisPathpointObject = this.pathpointObjects[p];
+        if (thisPathpointObject !== undefined) {
+            this.children[2*p].position.setFromMatrixPosition(thisPathpointObject.matrixWorld);
+            this.children[2*p].position.add(vec);
+            this.children[2*p].quaternion.setFromRotationMatrix(thisPathpointObject.matrixWorld);
+
+            var nextPathpointObject = this.pathpointObjects[p+1];
+            if(nextPathpointObject !== undefined) {
+              this.children[2*p+1].position.setFromMatrixPosition(nextPathpointObject.matrixWorld);
+              this.children[2*p+1].position.add(vec);
+              this.children[2*p+1].quaternion.setFromRotationMatrix(nextPathpointObject.matrixWorld);
+            }
+            else{
+
+              this.children[2*p+1].position.setFromMatrixPosition(thisPathpointObject.matrixWorld);
+              this.children[2*p+1].position.add(vec);
+              this.children[2*p+1].quaternion.setFromRotationMatrix(thisPathpointObject.matrixWorld);
+            }
+
+            if (this.DEBUG) {
+                console.warn("Path point name: " + thisPathpointObject.name);
+                console.warn("Num pathpoints = " + this.pathpoints.length);
+                console.warn("Num bones = " + this.children.length);
+                console.warn("This is vec:" + vec.toArray());
+                console.dir(this.children[2*p+1]);
+                this.DEBUG = false;
+            }
             //bones[b].pos.setFromMatrixPosition(pptObject.matrixWorld);
             //console.warn('bone '+b+' pos ='+bones[b].position.x, bones[b].position.y, bones[b].position.z);
-            this.children[b].updateMatrixWorld();
+            this.children[2*p].updateMatrixWorld();
+            this.children[2*p+1].updateMatrixWorld();
         }
     }
     this.skeleton.update();

--- a/editor/js/SkinnedMuscle.js
+++ b/editor/js/SkinnedMuscle.js
@@ -98,10 +98,7 @@ THREE.SkinnedMuscle.prototype.updateMatrixWorld = function( force ) {
             // the orientation of the bone is updated to have its Y-axis pointed
             // back along the vector from pt1 to pt2
             bones[b].position.add(vec);
-            bones[b].quaternion.setFromUnitVectors(vFrom, vTo);
-
-            bones[b-1].updateMatrixWorld();
-            bones[b++].updateMatrixWorld();
+            bones[b++].quaternion.setFromUnitVectors(vFrom, vTo);
         }
     }
     this.skeleton.update();


### PR DESCRIPTION
This PR fixes [GUI issue #240](https://github.com/opensim-org/opensim-gui/issues/240) where ends of the cylinders being skinned (call bones) were not correctly oriented. They are now continually updated and oriented so their faces (normal) are aligned with the line connecting the two points that define a path segment. 

Before:
![opensim_muscle_flattening](https://user-images.githubusercontent.com/6494122/28242857-20985402-696c-11e7-9e5d-394886c7ceb0.jpg)

After fix:
![opensim_muscle_flattening_fixed](https://user-images.githubusercontent.com/6494122/28242861-2c18d4c8-696c-11e7-90e9-d6007b288623.jpg)
