### PR TITLE
Save screenshots as PNG

### DIFF
--- a/editor/js/OpenSimToolbar.js
+++ b/editor/js/OpenSimToolbar.js
@@ -185,8 +185,8 @@ var OpenSimToolbar = function ( editor ) {
             var canvas = document.getElementById("viewport");
             getImageData = true;
             //canvas.children[1].render();
-	    var img    = canvas.children[0].toDataURL("image/jpeg");
-	    saveFile(img, "opensim_snapshot.jpg");
+	    var img    = canvas.children[0].toDataURL("image/png");
+	    saveFile(img, "opensim_snapshot.png");
 	};
         // Support saving image to file
         var saveFile = function (strData, filename) {


### PR DESCRIPTION
PNG is a lossless file format, and we are not concerned about file size. I tested this on my mac.

Ideally, we would also temporarily increase the canvas size so that we could save the image in a high resolution.