### PR TITLE
[WIP] Shadow not behind model

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -167,7 +167,7 @@
 				this.sceneLightY = -0.01;
 				this.sceneLightZ = -0.01;
 				this.sceneLightColor = [255, 255, 255];
-				this.sceneLightSelect = function () { editor.select(editor.sceneLight); }
+				this.sceneLightSelect = function () { editor.select(editor.scene.getObjectByName('SunLight')); }
 				this.modelLightSelect = function () { editor.selectCurrentModelLight(); }
 				this.toggleMarkup = function () { editor.toggleMarkup(); }
 				this.expertModeSelect = function () { editor.setTheme('css/dark.css'); }
@@ -190,7 +190,7 @@
 				    editor.updateBackgroundColor(value);
                                     //editor.updateBackground('nobackground');
                             });
-                            //world.add(knobs, 'sceneLightSelect').name('Scene Light');
+                            gui.add(knobs, 'sceneLightSelect').name('Scene Light');
                             //var model_control = gui.addFolder('Model');
                             // model_control.add(knobs, 'modelLightSelect').name('Model Light');
                             //gui.add(knobs, 'toggleMarkup').name('Toggle Markup');

--- a/editor/js/OpenSimEditor.js
+++ b/editor/js/OpenSimEditor.js
@@ -719,18 +719,18 @@ OpenSimEditor.prototype = {
 		amb.intensity = 0.2;
 		this.addObject(amb);
 		sceneLightColor = new THREE.Color().setHex(12040119);
-		directionalLight =  new THREE.DirectionalLight( sceneLightColor);
-		directionalLight.castShadow = true;
-		directionalLight.name = 'SceneLight';
-		directionalLight.shadow.camera.bottom = -2000;
-		directionalLight.shadow.camera.far = 8000;
-		directionalLight.shadow.camera.left = -2000;
-		directionalLight.shadow.camera.right = 2000;
-		directionalLight.shadow.camera.top = 2000;
-		directionalLight.shadow.mapSize.width = 1024;
-		directionalLight.shadow.mapSize.height = 1024;
+ 		directionalLight =  new THREE.DirectionalLight( sceneLightColor);
+// 		directionalLight.castShadow = true;
+// 		directionalLight.name = 'SceneLight';
+// 		directionalLight.shadow.camera.bottom = -2000;
+// 		directionalLight.shadow.camera.far = 8000;
+// 		directionalLight.shadow.camera.left = -2000;
+// 		directionalLight.shadow.camera.right = 2000;
+// 		directionalLight.shadow.camera.top = 2000;
+// 		directionalLight.shadow.mapSize.width = 1024;
+// 		directionalLight.shadow.mapSize.height = 1024;
 		// for debugging. not working directionalLight.shadowCameraVisible = true;
-		directionalLight.visible = true;
+	//	directionalLight.visible = true;
 		this.sceneLight = directionalLight;
 		this.addObject(directionalLight);
         // HemisphericalLight 
@@ -738,6 +738,61 @@ OpenSimEditor.prototype = {
 		hemiSphereLight.name = 'GlobalLight';
 		hemiSphereLight.intensity = 0.40;
 		//this.addObject(hemiSphereLight);
+
+      //   sunLight =  new THREE.SpotLight( {color: sceneLightColor});
+// 	    sunLight.castShadow = true;
+// 	    //sunLight.angle = 0.5;
+// 	    sunLight.intensity = 10.0;	
+// 	    sunLight.name = 'SunLight';
+// 	    sunLight.shadow.camera.bottom = -1000;
+// 	    sunLight.shadow.camera.far = 2000;
+// 	    sunLight.shadow.camera.left = -1000;
+// 	    sunLight.shadow.camera.right = 1000;
+// 	    sunLight.shadow.camera.top = 1000;
+//         sunLight.position.x = 0;
+//         sunLight.position.y = 0;
+//         sunLight.position.z = 1000;
+// 	    //sunLight.position.copy(new THREE.Vector3((modelbbox.max.x+modelbbox.min.x)/2, 
+// 		//modelbbox.max.y+100, (modelbbox.min.z+modelbbox.max.z)/2));
+// 	    //sunLight.target = modelCenterGroup;
+// 	    this.addObject(sunLight);
+	    
+//        hemiLight = new THREE.HemisphereLight( 0xffffff, 0xffffff, 0.6 );
+//        hemiLight.color.setHSL( 0.6, 1, 0.6 );
+//        hemiLight.groundColor.setHSL( 0.095, 1, 0.75 );
+//        hemiLight.position.set( 0, 500, 0 );
+//        this.addObject(hemiLight);
+//
+//        //
+//
+        dirLight = new THREE.DirectionalLight( 0xffffff, 1 );
+        dirLight.intensity = 0.1;
+        dirLight.color.setHSL( 0.1, 1, 0.95 );
+        dirLight.position.set( 1, 3, -1 );
+        dirLight.position.multiplyScalar( 500 );
+        this.addObject(dirLight);
+
+        dirLight.castShadow = true;
+
+        //dirLight.shadow.mapSize.width = 2048;
+        //dirLight.shadow.mapSize.height = 2048;
+
+        //var d = 5000;
+
+        //dirLight.shadow.camera.left = -d;
+        //dirLight.shadow.camera.right = d;
+        //dirLight.shadow.camera.top = d;
+        //dirLight.shadow.camera.bottom = -d;
+ 		dirLight.shadow.camera.bottom = -2000;
+ 		dirLight.shadow.camera.far = 8000;
+ 		dirLight.shadow.camera.left = -2000;
+ 		dirLight.shadow.camera.right = 2000;
+ 		dirLight.shadow.camera.top = 2000;
+ 		dirLight.shadow.mapSize.width = 1024;
+ 		dirLight.shadow.mapSize.height = 1024;
+
+        //dirLight.shadow.camera.far = 3500;
+        dirLight.shadow.bias = -0.0001;
 	},
 
 	updateBackground: function (choice) {

--- a/editor/js/OpenSimEditor.js
+++ b/editor/js/OpenSimEditor.js
@@ -767,7 +767,7 @@ OpenSimEditor.prototype = {
 //
         dirLight = new THREE.DirectionalLight( 0xffffff, 1 );
         dirLight.name = 'SunLight';
-        dirLight.intensity = 0.1;
+        dirLight.intensity = 0.2;
         dirLight.color.setHSL( 0.1, 1, 0.95 );
         dirLight.position.set( 1, 3, -1 );
         dirLight.position.multiplyScalar( 500 );

--- a/editor/js/OpenSimEditor.js
+++ b/editor/js/OpenSimEditor.js
@@ -766,6 +766,7 @@ OpenSimEditor.prototype = {
 //        //
 //
         dirLight = new THREE.DirectionalLight( 0xffffff, 1 );
+        dirLight.name = 'SunLight';
         dirLight.intensity = 0.1;
         dirLight.color.setHSL( 0.1, 1, 0.95 );
         dirLight.position.set( 1, 3, -1 );
@@ -950,8 +951,8 @@ OpenSimEditor.prototype = {
 	    if (modelObject != undefined)
 		modelObject.add(helper);
 	    */
-	    builtinLight = this.scene.getObjectByName('SceneLight');
-	    builtinLight.position.copy(new THREE.Vector3(modelbbox.max.x, modelbbox.max.y+100, modelbbox.min.z));
+	    builtinLight = this.scene.getObjectByName('SunLight');
+	    builtinLight.position.copy(new THREE.Vector3(modelbbox.max.x-100, modelbbox.max.y+100, modelbbox.min.z-400));
 	    this.signals.cameraChanged.dispatch(this.camera);
 	    // Move dolly to middle hight of bbox and make it invisible
 	    this.dolly_object.position.y = (modelbbox.max.y + modelbbox.min.y) / 2;


### PR DESCRIPTION
This is a first attempt at not placing the shadow behind the model:

<img width="372" alt="screen shot 2017-07-19 at 3 34 00 pm" src="https://user-images.githubusercontent.com/846001/28352094-cc6f0e46-6c97-11e7-9cfb-e9fa774f2ec4.png">

This is partially copied from the flamingo example, which it seems like @aymanhab may have also been trying to work off of. https://threejs.org/examples/webgl_lights_hemisphere.html

This is not ready to be merged. I won't have time to work on this again before ISB; others could pick up on ths if they're interested.