### PR TITLE
Pass active array along with PathPoints to visulaization code

### DIFF
--- a/editor/js/OpenSimLoader.js
+++ b/editor/js/OpenSimLoader.js
@@ -563,7 +563,7 @@ Object.assign( THREE.OpenSimLoader.prototype, {
                                         break;
 
 			    case 'GeometryPath':
-                                        object = new THREE.SkinnedMuscle(getGeometry(data.geometry), data.points,  getMaterial( data.material ));
+                                        object = new THREE.SkinnedMuscle(getGeometry(data.geometry),  getMaterial( data.material ), data.points, data.active);
 
                                         break;
 

--- a/editor/js/SkinnedMuscle.js
+++ b/editor/js/SkinnedMuscle.js
@@ -1,10 +1,11 @@
 /**
  * @author Ayman Habib
  */
-THREE.SkinnedMuscle = function(geom, points, material) {
+THREE.SkinnedMuscle = function(geom, material, points, actives) {
     // Create bones for uuids in geometryPath
     this.pathpoints = points;
     this.pathpointObjects = [];
+    this.actives = actives;
     geom.bones = [];
 
     for (var i=0; i< 2*points.length-2; i++) {
@@ -19,10 +20,12 @@ THREE.SkinnedMuscle = function(geom, points, material) {
 
     for ( var i = 0; i < geom.vertices.length; i++ ) {
         var skinIndex = Math.floor(i / numVerticesPerLevel);
+        var pptIndex = Math.floor((skinIndex+1)/2);
+        var activePoint = this.actives[pptIndex];
         geom.skinIndices.push(new THREE.Vector4(skinIndex, skinIndex+1, skinIndex-1, 0));
         if(skinIndex > 0 && skinIndex < geom.bones.length-1) {
            // blend next and previous bone vertices to smoothen transitions
-            geom.skinWeights.push( new THREE.Vector4( 0.8, 0.1, 0.1, 0 ) );
+            geom.skinWeights.push( new THREE.Vector4( 1.0, 0.0, 0.0, 0 ) );
         }
         else { //but, strictly enforce the reaching of the end points
             geom.skinWeights.push( new THREE.Vector4( 1.0, 0, 0, 0 ) );


### PR DESCRIPTION
This is used to control blending of wrap points once passed in from GUI. Also restore default blending weight to 1 so that path points are on the path.