### PR TITLE
Fix path recreation on edit

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -203,7 +203,7 @@
 				// model_control.add(knobs, 'modelLightSelect').name('Model Light');
 				//gui.add(knobs, 'toggleMarkup').name('Toggle Markup');
 				gui.add(knobs, 'showStats').name('Show FPS');
-				gui.add(knobs, 'expertModeSelect').name('Expert Mode');
+				//gui.add(knobs, 'expertModeSelect').name('Expert Mode');
 							
 				// No save/retrieve settings
 				// gui.remember(knobs);

--- a/editor/js/OpenSimEditor.js
+++ b/editor/js/OpenSimEditor.js
@@ -1107,11 +1107,11 @@ OpenSimEditor.prototype = {
 	    }
 	    // remove from parent
 	    var newGeometry = new THREE.CylinderGeometry(8, 8, 0.1, 8, 2 * (pathEditJson.points.length-1) - 1, true);
-	    var newMuscle = new THREE.SkinnedMuscle(newGeometry, pathEditJson.points, pathMaterial);
+	    var newMuscle = new THREE.SkinnedMuscle(newGeometry, pathMaterial, pathEditJson.points);
 	    newMuscle.parent = pathParent;
 	    newMuscle.uuid = pathEditJson.uuid;
 	    // add to parent.
-	    this.addObject(newMuscle);
+	    pathParent.add(newMuscle);
 	    this.refresh();
 	},
 	toggleRecord: function () {

--- a/editor/js/SkinnedMuscle.js
+++ b/editor/js/SkinnedMuscle.js
@@ -21,7 +21,7 @@ THREE.SkinnedMuscle = function(geom, material, points, actives) {
     for ( var i = 0; i < geom.vertices.length; i++ ) {
         var skinIndex = Math.floor(i / numVerticesPerLevel);
         var pptIndex = Math.floor((skinIndex+1)/2);
-        var activePoint = this.actives[pptIndex];
+        //var activePoint = this.actives[pptIndex];
         geom.skinIndices.push(new THREE.Vector4(skinIndex, skinIndex+1, skinIndex-1, 0));
         if(skinIndex > 0 && skinIndex < geom.bones.length-1) {
            // blend next and previous bone vertices to smoothen transitions


### PR DESCRIPTION
When recreating Path due to Pathpoint add/delete, make sure the new Path has ground as parent rather than TopLevel so that it's removed on model close. Also update call site for SkinnedMuscle construction