### PR TITLE
Move location of capture text to Bottom so it's not hidden by buttons

### DIFF
--- a/editor/js/libs/CCapture.js
+++ b/editor/js/libs/CCapture.js
@@ -583,7 +583,7 @@ function CCapture( settings ) {
 	
 	var _timeDisplay = document.createElement( 'div' );
 	_timeDisplay.style.position = 'absolute';
-	_timeDisplay.style.left = _timeDisplay.style.top = 0
+	_timeDisplay.style.left = _timeDisplay.style.bottom = 0
 	_timeDisplay.style.backgroundColor = 'black';
 	_timeDisplay.style.fontFamily = 'monospace'
 	_timeDisplay.style.fontSize = '11px'


### PR DESCRIPTION
Move text for video capture to bottom of screen for better visibility