### PR TITLE
Propagate non editable children

### DIFF
--- a/editor/js/OpenSimEditor.js
+++ b/editor/js/OpenSimEditor.js
@@ -210,7 +210,7 @@ OpenSimEditor.prototype = {
 	moveObject: function ( object, parent, before ) {
 
 		if ( parent === undefined ) {
-
+			console.log('parent not found, using scene');
 			parent = this.scene;
 
 		}

--- a/editor/js/OpenSimLoader.js
+++ b/editor/js/OpenSimLoader.js
@@ -598,7 +598,11 @@ Object.assign( THREE.OpenSimLoader.prototype, {
 
 			if ( data.visible !== undefined ) object.visible = data.visible;
 			if ( data.userData !== undefined ) object.userData = data.userData;
-
+			if ( object.userData === 'NonEditable') { // Propagate to children if any
+				for ( var child in object.children ) {
+					object.children[child].userData = 'NonEditable';
+				}
+			}
 			if ( data.children !== undefined ) {
 
 				for ( var child in data.children ) {


### PR DESCRIPTION
When object is marked uneditable, propagate the flag to its children in the scene graph.