### PR TITLE
Use requestAnimationFrame to trigger recording

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -411,31 +411,11 @@
 
 			onWindowResize();
 
-			//
-
-			var isLoadingFromHash = false;
-			var file = 'model.json';
-			var hash = window.location.hash;
-
-			if ( true) {
-
-				//var file = hash.substr( 6 );
-
-				if ( false ) {
-
-					var loader = new THREE.XHRLoader();
-					loader.crossOrigin = '';
-					loader.load( file, function ( text ) {
-						var json = JSON.parse( text );
-						//editor.clear();
-						editor.addfromJSON( json );
-
-					} );
-
-					isLoadingFromHash = true;
-
-				}
-
+			animate();
+			function animate() {
+			    requestAnimationFrame(animate);
+                if (editor.recording)
+			        editor.signals.captureFrame.dispatch();
 			}
 
 		</script>

--- a/editor/js/OpenSimEditor.js
+++ b/editor/js/OpenSimEditor.js
@@ -16,7 +16,7 @@ var OpenSimEditor = function () {
 	this.dolly_object = new THREE.Object3D();
 	this.dolly_object.name = 'Dolly';
 	this.dolly_object.position.y = 0;
-		this.recording = false;
+	this.recording = false;
 
 	this.models = [];
 	this.currentModel = undefined; //uuid of current model call getCurrentModel for actualobject
@@ -99,7 +99,8 @@ var OpenSimEditor = function () {
 		recordingStarted: new Signal(),
 		recordingStopped: new Signal(),
 		hiresRender: new Signal(),
-		screenCaptureScaleupChanged: new Signal()
+		screenCaptureScaleupChanged: new Signal(),
+		captureFrame: new Signal(),
 	};
 
 	this.config = new Config( 'threejs-editor' );

--- a/editor/js/OpenSimViewport.js
+++ b/editor/js/OpenSimViewport.js
@@ -402,7 +402,7 @@ var OpenSimViewport = function ( editor ) {
 	        capturer = new CCapture({
 	            verbose: false,
 	            display: false,
-	            framerate: 15,
+	            framerate: 30,
 	            motionBlurFrames: 0,
 	            quality: 100,
                 name: "opensim_video",
@@ -436,7 +436,7 @@ var OpenSimViewport = function ( editor ) {
          capturer = new CCapture({
 	            verbose: false,
 	            display: false,
-	            framerate: 15,
+	            framerate: 30,
 	            motionBlurFrames: 0,
 	            quality: 100,
                 name: "opensim_video",
@@ -655,6 +655,11 @@ var OpenSimViewport = function ( editor ) {
 	signals.screenCaptureScaleupChanged.add(function (newFactor) {
 		screenCapUpsamplingFactor = newFactor;
 	});
+
+	signals.captureFrame.add(function () {
+	    if (recording && capturer !== undefined)
+	        capturer.capture(renderer.domElement);
+	});
 	//
 
 	var renderer = null;
@@ -770,7 +775,7 @@ var OpenSimViewport = function ( editor ) {
 		            renderer.render(sceneHelpers, camera);
 
 		    }
-		    if (recording) capturer.capture(renderer.domElement);
+		    //if (recording) capturer.capture(renderer.domElement);
 		}
 	}
 


### PR DESCRIPTION
Enable animation while recording/capturing. This works by re-introducing requestAnimationFrame and using it to trigger the capture thus avoiding interference with normal rendering. 