### PR TITLE
Make buttons have transparent background

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -192,6 +192,10 @@ textarea, input { outline: none; } /* osx */
     text-align: center;
     text-decoration: none;
     font-size: 10px;
+    background-color: Transparent;
+    border: none;
+    overflow: hidden;
+    outline:none;
 }
 #opensim_toolbar button img {
         width: 20px;


### PR DESCRIPTION
Make toolbar buttons have transparent background to reduce footprint/occlusion