### PR TITLE
Remove stale shortcuts

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -390,6 +390,7 @@
 
       //event.preventDefault(); // prevent browser back
       break;
+/*
       case 46: // delete
 
       var object = editor.selected;
@@ -432,6 +433,7 @@
 						editor.signals.transformModeChanged.dispatch( 'scale' );
 
 						break;
+*/
 					case 37: // Delegate ArrowKeys and OpenSim reserved keys to editor
 					case 38:
 					case 39:


### PR DESCRIPTION
Fix issue opensim-gui issues #695,  #698 caused by built-in binding of shortcuts to "Delete" and "Translate/Rotate/Scale" selected objects