### PR TITLE
Send offsets to GUI right after model loading

### DIFF
--- a/editor/js/OpenSimEditor.js
+++ b/editor/js/OpenSimEditor.js
@@ -1034,6 +1034,8 @@ OpenSimEditor.prototype = {
 		}
 		modelObject.position.z = sceneBox.max.z+modelbbox.max.z-modelbbox.min.z;
 		modelObject.getObjectByName('ModelLight').target.updateMatrixWorld();
+		// send message to GUI with computed offsets
+		sendText(this.getModelOffsetsJson());
 	},
 	addModelLight: function(model) {
 		var modelbbox = new THREE.Box3().setFromObject(model);


### PR DESCRIPTION
Send model offsets to GUI right after model loading instead of delayed until requested by GUI