### PR TITLE
Make controls menu span wider to avoid text cutoff

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -201,7 +201,7 @@
       }
       };
       window.onload = function () {
-      var gui = new dat.GUI(); // create dat.gui
+          var gui = new dat.GUI({ width: 260 }); // create dat.gui
       var knobs = new VisualizerKnobs();
       gui.remember(knobs);
 


### PR DESCRIPTION
Widen visualizer control menu to avoid text cutoff