### PR TITLE
Speedup animation visualizer

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -10,7 +10,7 @@
 		<link href="css/main.css" rel="stylesheet" />
 		<link id="theme" href="css/minimal.css" rel="stylesheet" />
 
-		<script src="../build/three.js"></script>
+		<script src="../build/three.min.js"></script>
 		<script src="js/SkinnedMuscle.js"></script>
 		<script src="js/OpenSimLoader.js"></script>
 		<script src="../examples/js/libs/system.min.js"></script>

--- a/editor/index.html
+++ b/editor/index.html
@@ -244,8 +244,10 @@
       modelLightIntensity.name('Model Light').onChange(function(value){
       editor.updateModelLightIntensity(value);
       });;
-      if (getParameterByName('expert') === "1")
-      gui.add(knobs, 'expertModeSelect').name('Expert Mode');
+      if (getParameterByName('expert') === "1"){
+        gui.add(knobs, 'expertModeSelect').name('Expert Mode');
+        gui.add(knobs, 'showStats').name('FPS');
+      }
       var captureControl = gui.add(knobs, 'screenCaptureDPI').name('Snapshot Quality').min(1).max(4).step(1);
       captureControl.onChange(function (value) {
       editor.setScreenCaptureScaleup(value);

--- a/editor/js/OpenSimEditor.js
+++ b/editor/js/OpenSimEditor.js
@@ -28,8 +28,10 @@ var OpenSimEditor = function () {
 	this.sceneLight = undefined;
 	this.modelLightIntensity = 0.25;
 	this.globalFrameGroup = undefined;
+	this.cache = Object.create(null);
 	// types of objects that are graphically movable
 	var supportedOpenSimTypes = ["PathPoint", "Marker"];
+    this.reportframeTime = false;
 	//this.cameraEye = new THREE.Mesh(new THREE.SphereGeometry(50), new THREE.MeshBasicMaterial({ color: 0xdddddd }));
 	//this.cameraEye.name = 'CameraEye';
 
@@ -558,10 +560,18 @@ OpenSimEditor.prototype = {
 			this.signals.sceneGraphChanged.dispatch();
 			if (!this.isExperimentalDataModel(model) || this.models.length==1)
 			    this.viewFitAll();
+            
 			this.signals.windowResize.dispatch();
+
+			this.buildCache(model);
 		}
 	},
-	
+	buildCache: function( model) {
+	    modelobject.traverse(function (child) {
+	        if (child.type === "Group")
+	            editor.cache[child.uuid] = child;
+	    });
+	},
 	loadModel: function ( modelJsonFileName) {
 		var loader = new THREE.XHRLoader();
 		loader.crossOrigin = '';
@@ -592,11 +602,11 @@ OpenSimEditor.prototype = {
 		this.signals.sceneGraphChanged.dispatch();
 	},
 	setCurrentModel: function ( modeluuid ) {
-		if (this.currentModel == modeluuid) 
-		return; // Nothing to do
+		if (this.currentModel === modeluuid) 
+			return; // Nothing to do
 		this.currentModel = modeluuid;
-		if (this.currentModel == undefined)
-		return;
+		if (this.currentModel === undefined)
+			return;
 		newCurrentModel = editor.objectByUuid(modeluuid);
 		// Dim light for all other models and make the model have shadows, 
 		// Specififc light
@@ -616,7 +626,7 @@ OpenSimEditor.prototype = {
 			this.enableShadows(other_uuid, false);
 		}
 		}
-		this.signals.sceneGraphChanged.dispatch();
+		//this.signals.sceneGraphChanged.dispatch();
 	},
 	toJSON: function () {
 
@@ -656,10 +666,13 @@ OpenSimEditor.prototype = {
 
 	},
 
-	objectByUuid: function ( uuid ) {
-
-		return this.scene.getObjectByProperty( 'uuid', uuid, true );
-
+	objectByUuid: function (uuid) {
+	    var Object = this.cache[uuid];
+	    if (Object !== undefined)
+	        return Object;
+        Object = this.scene.getObjectByProperty( 'uuid', uuid, true );
+        this.cache[uuid] = Object;
+        return Object;
 	},
 
 	execute: function ( cmd, optionalName ) {
@@ -1271,6 +1284,14 @@ OpenSimEditor.prototype = {
             offsets.positions.push(nextModel.position);
         };
         return JSON.stringify(offsets);
+    },
+    reportRenderTime: function(frameRenderTime) {
+        var info = {
+            "type": "info",
+            "renderTime":frameRenderTime
+        };
+        this.reportframeTime = false;
+        sendText(JSON.stringify(info));
     }
 
 };

--- a/editor/js/OpenSimViewport.js
+++ b/editor/js/OpenSimViewport.js
@@ -802,8 +802,10 @@ var OpenSimViewport = function ( editor ) {
 	            }
 	            //if (recording) capturer.capture(renderer.domElement);
 	        }
-	        //var t1 = performance.now();
-	        //console.log('Render time', t1 - t0);
+                if (editor.reportframeTime){
+                    var t1 = performance.now();
+                    editor.reportRenderTime(t1-t0);
+                }
 	    }
 	}
 

--- a/editor/websocket.js
+++ b/editor/websocket.js
@@ -65,8 +65,10 @@ function onMessage(evt) {
 				editor.updatePath(paths[p]);
 			}
 		}
-		editor.refresh();
+		if (msg.render===true) // not undefined
+			editor.refresh();
 		var t1 = performance.now() - t0;
+		//console.log("frame time: " + t1);
 		totalTime +=t1;
 		numFrames++;
 		processing = false;


### PR DESCRIPTION
Part of the fix to speed up animation on visualizer side. 
- Use explicit flag sent across websocket to refresh display after applying frame
- Avoid applying frame messages that are sent multiple times by websocket 
- Send rendertime to GUI to regulate frame rate.
- Cache UUIDs to speed up lookup when applying animation frames