### PR TITLE
Use undefined instead of null for empty cache entries

### DIFF
--- a/editor/js/OpenSimEditor.js
+++ b/editor/js/OpenSimEditor.js
@@ -210,7 +210,7 @@ OpenSimEditor.prototype = {
 			scope.addHelper( child );
 
 		} );
-		if (object.parent !== null)
+		if (object.parent !== null && object.parent !== undefined)
 			object.parent.add(object);
 		else
 			this.scene.add( object );
@@ -264,7 +264,7 @@ OpenSimEditor.prototype = {
 		} );
 
 		object.parent.remove( object );
-		this.cache[object.uuid] = null;
+		this.cache[object.uuid] = undefined;
 		this.signals.objectRemoved.dispatch( object );
 		this.signals.sceneGraphChanged.dispatch();
 
@@ -564,6 +564,11 @@ OpenSimEditor.prototype = {
 			this.signals.windowResize.dispatch();
 
 			this.buildCache(model);
+			var msg = {
+			    "type": "acknowledge",
+			    "uuid": model.uuid
+			};
+			sendText(JSON.stringify(msg));
 		}
 	},
 	buildCache: function( model) {
@@ -584,7 +589,7 @@ OpenSimEditor.prototype = {
 	},
 	enableShadows: function (modeluuid, newSetting) {
 		modelobject = editor.objectByUuid(modeluuid);
-		if (modelobject != undefined){
+		if (modelobject !== undefined){
 		modelobject.traverse( function ( child ) {
 			if (child instanceof THREE.Mesh)
 			child.castShadow = newSetting;
@@ -1150,7 +1155,7 @@ OpenSimEditor.prototype = {
 	},
 	updatePath: function (pathUpdateJson) {
 		var pathObject = this.objectByUuid(pathUpdateJson.uuid);
-		if (pathObject !== null)
+		if (pathObject !== undefined)
 			pathObject.setColor(pathUpdateJson.color);
 	},
 	processPathEdit: function (pathEditJson) {

--- a/editor/js/commands/RemoveObjectCommand.js
+++ b/editor/js/commands/RemoveObjectCommand.js
@@ -33,11 +33,12 @@ RemoveObjectCommand.prototype = {
 		this.object.traverse( function ( child ) {
 
 			scope.removeHelper( child );
+			scope.cache[child.uuid]=undefined;
 
 		} );
         if (this.parent.children.indexOf (this.object) !== -1) {
 		    this.parent.remove( this.object );
-		    this.editor.cache[this.object.uuid]=null;
+		    //this.editor.cache[this.object.uuid]=undefined;
 		}
         else 
             scope.scene.remove( this.object );


### PR DESCRIPTION
 Also remove all children from cache on object removal, and send notification back to GUI on finishing model load.