### PR TITLE
Visualizer handles no Ctrl-Key combinations 

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -378,7 +378,7 @@
       }, false );
 
       document.addEventListener( 'keydown', function ( event ) {
-
+	  // Visualizer to ignore key combinations using "ctrl" to avoid breaking GUI hot-keys
 	  if ( event.ctrlKey)
 	  	return;
 	  	

--- a/editor/index.html
+++ b/editor/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 	<head>
 		<title>OpenSim 4.0 Visualizer 040417</title>
@@ -379,6 +379,9 @@
 
       document.addEventListener( 'keydown', function ( event ) {
 
+	  if ( event.ctrlKey)
+	  	return;
+	  	
       switch ( event.keyCode ) {
 
       case 8: // backspace


### PR DESCRIPTION
Ctrl+Key are used as Hot-keys in GUI and never by visualizer. This change avoids handling ctrl-key combinations in visualizer, causing issue #840 of GUI