### PR TITLE
Use Red rather than gray as record button backgnd when recording

### DIFF
--- a/editor/js/OpenSimToolbar.js
+++ b/editor/js/OpenSimToolbar.js
@@ -188,7 +188,7 @@ var OpenSimToolbar = function ( editor ) {
 	var recordStatus = false;
 	recordButton.onClick(function () {
 		recordStatus = !recordStatus;
-		if (recordStatus) // Dark gray if recording, should be done in CSS
+		if (recordStatus) // Dark red if recording, should be done in CSS
 			recordButton.dom.style.backgroundColor = "#FF0808";
 		else // default
 			recordButton.dom.style.backgroundColor = "";

--- a/editor/js/OpenSimToolbar.js
+++ b/editor/js/OpenSimToolbar.js
@@ -189,7 +189,7 @@ var OpenSimToolbar = function ( editor ) {
 	recordButton.onClick(function () {
 		recordStatus = !recordStatus;
 		if (recordStatus) // Dark gray if recording, should be done in CSS
-			recordButton.dom.style.backgroundColor = "#888888";
+			recordButton.dom.style.backgroundColor = "#FF0808";
 		else // default
 			recordButton.dom.style.backgroundColor = "";
 		toggleRecord();


### PR DESCRIPTION
Avoid conflict with commonly used gray background